### PR TITLE
More descriptive error reporting

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source "http://rubygems.org"
 
-gem 'json'
-gem 'typhoeus'
+gem 'json', '~> 2.6'
+gem 'typhoeus', '~> 1.4'
 
 group :test do
   gem 'rspec', :require => "spec"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,26 +1,34 @@
 GEM
   remote: http://rubygems.org/
   specs:
-    diff-lcs (1.2.4)
-    ethon (0.7.0)
-      ffi (>= 1.3.0)
-    ffi (1.9.3)
-    json (1.7.7)
-    rspec (2.13.0)
-      rspec-core (~> 2.13.0)
-      rspec-expectations (~> 2.13.0)
-      rspec-mocks (~> 2.13.0)
-    rspec-core (2.13.1)
-    rspec-expectations (2.13.0)
-      diff-lcs (>= 1.1.3, < 2.0)
-    rspec-mocks (2.13.1)
-    typhoeus (0.6.8)
-      ethon (>= 0.7.0)
+    diff-lcs (1.5.1)
+    ethon (0.16.0)
+      ffi (>= 1.15.0)
+    ffi (1.17.1)
+    json (2.9.1)
+    rspec (3.13.0)
+      rspec-core (~> 3.13.0)
+      rspec-expectations (~> 3.13.0)
+      rspec-mocks (~> 3.13.0)
+    rspec-core (3.13.2)
+      rspec-support (~> 3.13.0)
+    rspec-expectations (3.13.3)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-mocks (3.13.2)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-support (3.13.2)
+    typhoeus (1.4.1)
+      ethon (>= 0.9.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  json
+  json (~> 2.6)
   rspec
-  typhoeus
+  typhoeus (~> 1.4)
+
+BUNDLED WITH
+   2.5.6

--- a/lib/canvas-api.rb
+++ b/lib/canvas-api.rb
@@ -128,15 +128,15 @@ module Canvas
       rescue Timeout::Error => e
         raise ApiError.new("request timed out")
       end
-      raise ApiError.new("unexpected redirect to #{response.headers['Location']}") if response.code.to_s.match(/3\d\d/)
+      raise ApiError.new("unexpected redirect to #{response.headers['Location']}, status: #{response.code}") if response.code.to_s.match(/3\d\d/)
       json = JSON.parse(response.body) rescue {'error' => 'invalid JSON'}
       if !json.is_a?(Array)
-        raise ApiError.new("#{json['error']} #{response.body}") if json['error']
+        raise ApiError.new("#{json['error']} '#{response.body}', status: #{response.code}") if json['error']
         raise ApiError.new(json['errors']) if json['errors']
         if !response.code.to_s.match(/2\d\d/)
           json['message'] ||= "unexpected error"
           json['status'] ||= response.code.to_s
-          raise ApiError.new("#{json['status']} #{json['message']}") 
+          raise ApiError.new("#{json['message']}, status: #{json['status']}")
         end
       else
         json = ResultSet.new(self, json)

--- a/lib/canvas-api.rb
+++ b/lib/canvas-api.rb
@@ -70,7 +70,7 @@ module Canvas
         :replace_tokens => true,
         :grant_type => (grant_type || 'authorization_code')
       }.tap { |opts|
-        opts[:scope] = scope.join(' ') if scope.present?
+        opts[:scope] = scope.join(' ') if !scope.nil? && scope.present?
       }
 
       res = post("/login/oauth2/token", opts)

--- a/lib/canvas-api.rb
+++ b/lib/canvas-api.rb
@@ -70,7 +70,7 @@ module Canvas
         :replace_tokens => true,
         :grant_type => (grant_type || 'authorization_code')
       }.tap { |opts|
-        opts[:scope] = scope.join(' ') if !scope.nil? && scope.present?
+        opts[:scope] = scope.join(' ') unless scope.nil?
       }
 
       res = post("/login/oauth2/token", opts)

--- a/lib/canvas-api.rb
+++ b/lib/canvas-api.rb
@@ -290,7 +290,14 @@ module Canvas
     end
   end
 
-  class ApiError < StandardError; end
+  class ApiError < StandardError
+    def response_status
+      matches = message.match(/status: (\d+)/)
+
+      return nil unless matches
+      matches[1]
+    end
+  end
 
   class ResultSet < Array
     def initialize(api, arr)

--- a/spec/api_error_spec.rb
+++ b/spec/api_error_spec.rb
@@ -1,0 +1,13 @@
+require "spec_helper"
+
+describe "ApiError" do
+  it "should return the response_status if set in message" do
+    error = Canvas::ApiError.new("Some terrible error message, status: 422")
+    expect(error.response_status).to eq '422'
+  end
+
+  it "should return nil response_status if not set in message" do
+    error = Canvas::ApiError.new("Some terrible error message")
+    expect(error.response_status).to eq nil
+  end
+end

--- a/spec/get_requests_spec.rb
+++ b/spec/get_requests_spec.rb
@@ -67,7 +67,7 @@ describe "GET requests" do
       @api.generate_uri("/api/v1/bacon")
       stub_request("/api/v1/bacon", :code => 302, :location => "http://www.example.com")
       req = @api.get_request("/api/v1/bacon")
-      expect { @api.retrieve_response(req) }.to raise_error(Canvas::ApiError, "unexpected redirect to http://www.example.com")
+      expect { @api.retrieve_response(req) }.to raise_error(Canvas::ApiError, "unexpected redirect to http://www.example.com, status: 302")
     end
     
     it "should raise on non-200 response" do
@@ -75,7 +75,7 @@ describe "GET requests" do
       @api.generate_uri("/api/v1/bacon")
       stub_request("/api/v1/bacon", :code => 400, :body => {}.to_json)
       req = @api.get_request("/api/v1/bacon")
-      expect { @api.retrieve_response(req) }.to raise_error(Canvas::ApiError, "400 unexpected error")
+      expect { @api.retrieve_response(req) }.to raise_error(Canvas::ApiError, "unexpected error, status: 400")
     end
     
     it "should parse error messages" do
@@ -83,7 +83,7 @@ describe "GET requests" do
       @api.generate_uri("/api/v1/bacon")
       stub_request("/api/v1/bacon", :code => 400, :body => {:message => "bad message", :status => "invalid"}.to_json)
       req = @api.get_request("/api/v1/bacon")
-      expect { @api.retrieve_response(req) }.to raise_error(Canvas::ApiError, "invalid bad message")
+      expect { @api.retrieve_response(req) }.to raise_error(Canvas::ApiError, "bad message, status: invalid")
     end
     
     it "should raise on non-JSON response" do
@@ -91,7 +91,7 @@ describe "GET requests" do
       @api.generate_uri("/api/v1/bacon")
       stub_request("/api/v1/bacon", :code => 400, :body => "<xml/>")
       req = @api.get_request("/api/v1/bacon")
-      expect { @api.retrieve_response(req) }.to raise_error(Canvas::ApiError, "invalid JSON")
+      expect { @api.retrieve_response(req) }.to raise_error(Canvas::ApiError, "invalid JSON '<xml/>', status: 400")
     end
     
     it "should return JSON on valid response" do


### PR DESCRIPTION
I want to track Canvas authentication failures and see what status was returned. The current format of API errors obscures what's going on. For example, we know we're being rate limited if we get back a 202 error, and that the service is down if we get a 504. Currently in both cases this gem raises an ApiError with the message "Invalid JSON"

With these changes the error returned will be "Invalid JSON, status: 202" or "Invalid JSON, status: 504"

Also added a convenience method so we can do stuff like:

```
rescue Canvas::ApiError => e
      Appsignal.increment_counter("canvas_authentication_error_#{e.response_status}")

     ...
end
```